### PR TITLE
Performing resource replacements for localhost using TaskResourceMappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.1.3
+
+- Allow for resource replacements for local development using custom `TaskResourceMapping` configuration

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ It also adds an environment variable for each created state machine that contain
 - `region` (required) your AWS region
 - `lambdaEndpoint` (defaults to `http://localhost:4000`) the endpoint for the lambda service
 - `path` (defaults to `./.step-functions-local`) the path to store the downloaded step function executables
+- `TaskResourceMapping` allows for Resource ARNs to be configured differently for local development
 
 ### Full Config Example
 
@@ -72,6 +73,9 @@ custom:
   stepFunctionsLocal:
     accountId: 101010101010
     region: us-east-1
+    TaskResourceMapping:
+      FirstState: arn:aws:lambda:us-east-1:101010101010:function:hello
+      FinalState: arn:aws:lambda:us-east-1:101010101010:function:hello
 
 functions:
   hello:
@@ -86,7 +90,7 @@ stepFunctions:
         States:
           FirstState:
             Type: Task
-            Resource: arn:aws:lambda:us-east-1:101010101010:function:hello
+            Resource: Fn::GetAtt: [hello, Arn]
             Next: wait_using_seconds
           wait_using_seconds:
             Type: Wait
@@ -94,6 +98,6 @@ stepFunctions:
             Next: FinalState
           FinalState:
             Type: Task
-            Resource: arn:aws:lambda:us-east-1:101010101010:function:hello
+            Resource: Fn::GetAtt: [hello, Arn]
             End: true
 ```

--- a/index.js
+++ b/index.js
@@ -79,6 +79,28 @@ class ServerlessStepFunctionsLocal {
     const parsed = await this.serverless.yamlParser.parse(configPath);
 
     this.stateMachines = parsed.stepFunctions.stateMachines;
+
+    if (parsed.custom 
+      && parsed.custom.stepFunctionsLocal
+      && parsed.custom.stepFunctionsLocal.TaskResourceMapping) {
+        this.replaceTaskResourceMappings(parsed.stepFunctions.stateMachines, parsed.custom.stepFunctionsLocal.TaskResourceMapping);
+    }
+  }
+
+  /**
+   * Replaces Resource properties with values mapped in TaskResourceMapping
+   */
+  replaceTaskResourceMappings(input, replacements, parentKey) {
+    for(var key in input) {
+      var property = input[key];
+      if (['object', 'array'].indexOf(typeof property) > -1) {
+        if (input['Resource'] && replacements[parentKey]) {
+          input['Resource'] = replacements[parentKey];
+        }
+        // Recursive replacement of nested states
+        this.replaceTaskResourceMappings(property, replacements, key);
+      }
+    }
   }
 
   async createEndpoints() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-step-functions-local",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-step-functions-local",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Run AWS step functions offline with Serverless",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
See https://github.com/codetheweb/serverless-step-functions-local/issues/1 for details on the issue.

`Resource` overrides within the step function configuration using a custom plugin configuration `TaskResourceMapping`. This object contains a key of the State name, and a value for the desired resource ARN.

This allows for local development to use a different ARN than deployments.

@codetheweb  