### PR TITLE
feat: Enable Eventbridge Execution Status Change Event

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ It also adds an environment variable for each created state machine that contain
 - `lambdaEndpoint` (defaults to `http://localhost:4000`) the endpoint for the lambda service
 - `path` (defaults to `./.step-functions-local`) the path to store the downloaded step function executables
 - `TaskResourceMapping` allows for Resource ARNs to be configured differently for local development
+- `eventBridgeEvents` allows sending [EventBridge events](https://docs.aws.amazon.com/step-functions/latest/dg/cw-events.html) on execution status changes
+  - `enabled` (bool) enabled or disable this feature. Disabled by default.
+  - `endpoint` Endpoint for sending events to eg. for [serverless-offline-aws-eventbridge](https://github.com/rubenkaiser/serverless-offline-eventBridge) would be `http://localhost:4010`
 
 ### Full Config Example
 
@@ -77,6 +80,9 @@ custom:
     TaskResourceMapping:
       FirstState: arn:aws:lambda:us-east-1:101010101010:function:hello
       FinalState: arn:aws:lambda:us-east-1:101010101010:function:hello
+    eventBridgeEvents:
+      enabled: true
+      endpoint: http://localhost:4010
 
 functions:
   hello:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-step-functions-local",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-step-functions-local",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Run AWS step functions offline with Serverless",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Purpose

AWS Step Functions emits EventBridge events on execution state changes (docs [here](https://docs.aws.amazon.com/step-functions/latest/dg/cw-events.html)). This is particularly useful when kicking off other tasks when an execution starts or fails, and there's no way to currently test this functionality locally.

## Approach

Step Functions Local itself does not seem to support this functionality, but we can infer the state changes from the logs and fire the respective events.

The event details aren't fully implemented:
- `startDate` for all events except `ExecutionStarted`
There's no information on a specific log line on when the execution started. It can only populate `stopDate` for these end states.
- `input` and `output`
There's some logic involved in whether the details are shown (docs [here](https://docs.aws.amazon.com/step-functions/latest/apireference/API_DescribeExecution.html)). But if there's a feature request for this information it shouldn't be impossible to implement.