### PR TITLE
fix: Properly parse server stdout as lines

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const StepFunctionsLocal = require('stepfunctions-localhost');
 const AWS = require('aws-sdk');
 const tcpPortUsed = require('tcp-port-used');
 const chalk = require('chalk');
+const readLine = require('readline');
 
 class ServerlessStepFunctionsLocal {
   constructor(serverless, options) {
@@ -57,15 +58,17 @@ class ServerlessStepFunctionsLocal {
   }
 
   async startStepFunctions() {
-    this.stepfunctionsServer.start({
+    let serverStdout = this.stepfunctionsServer.start({
       account: this.config.accountId.toString(),
       lambdaEndpoint: this.config.lambdaEndpoint,
       region: this.config.region
-    }).on('data', data => {
-      console.log(chalk.blue('[Serverless Step Functions Local]'), data.toString());
+    });
+
+    readLine.createInterface({ input: serverStdout }).on('line', line => {
+      console.log(chalk.blue('[Serverless Step Functions Local]'), line.trim());
 
       if (this.eventBridgeEventsEnabled) {
-        this.sendEventBridgeEvent(data.toString());
+        this.sendEventBridgeEvent(line.trim());
       }
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-step-functions-local",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-step-functions-local",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Run AWS step functions offline with Serverless",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Purpose

The `stdout` output from the server process currently does not properly handle newlines. This results in inconsistent formatting where there are some empty lines, and some log lines with multiple lines of text.

Beyond just aesthetics, this causes issues when firing EventBridge events implemented here (https://github.com/codetheweb/serverless-step-functions-local/pull/7) as the regex assumes the input is a single line.

**Current**
```
[Serverless Step Functions Local] Step Functions Local
[Serverless Step Functions Local] 

[Serverless Step Functions Local] Version: 1.7.9
Build: 2021-06-24

[Serverless Step Functions Local] 
[Serverless Step Functions Local] 2021-09-29 08:07:29.683: Configure [AWS_DEFAULT_REGION] to [us-east-1]
[Serverless Step Functions Local] 

[Serverless Step Functions Local] 2021-09-29 08:07:29.685: Configure [DYNAMODB_ENDPOINT] to [http://localhost:4566]

[Serverless Step Functions Local] 2021-09-29 08:07:29.685: Configure [STEP_FUNCTIONS_ENDPOINT] to [http://localhost:8083]
[Serverless Step Functions Local] 

[Serverless Step Functions Local] 
[Serverless Step Functions Local] 2021-09-29 08:07:29.704: Configure [Account] to [101010101010]

[Serverless Step Functions Local] 2021-09-29 08:07:29.705: Configure [Region] to [us-east-1]

[Serverless Step Functions Local] 2021-09-29 08:07:29.705: Configure [Lambda Endpoint] to [http://localhost:3002]
```

**New**

```
[Serverless Step Functions Local] Step Functions Local
[Serverless Step Functions Local] Version: 1.7.9
[Serverless Step Functions Local] Build: 2021-06-24
[Serverless Step Functions Local] 2021-09-29 16:57:48.371: Configure [AWS_DEFAULT_REGION] to [us-east-1]
[Serverless Step Functions Local] 2021-09-29 16:57:48.372: Configure [DYNAMODB_ENDPOINT] to [http://localhost:4566]
[Serverless Step Functions Local] 2021-09-29 16:57:48.372: Configure [STEP_FUNCTIONS_ENDPOINT] to [http://localhost:8083]
[Serverless Step Functions Local] 2021-09-29 16:57:48.379: Configure [Account] to [101010101010]
[Serverless Step Functions Local] 2021-09-29 16:57:48.379: Configure [Region] to [us-east-1]
[Serverless Step Functions Local] 2021-09-29 16:57:48.380: Configure [Lambda Endpoint] to [http://localhost:3002]
```