### PR TITLE
feat: Use new serverless resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This is a plugin for the [Serverless Framework](https://serverless.com/).  It us
 
 ## Requirements
 
+- serverless >= v2.32.0
 - The [serverless-offline](https://www.npmjs.com/package/serverless-offline) plugin
 - The [serverless-offline-lambda](https://www.npmjs.com/package/serverless-offline-lambda) plugin
 - The [serverless-step-functions](https://www.npmjs.com/package/serverless-step-functions) plugin
@@ -35,7 +36,6 @@ custom:
   stepFunctionsLocal:
     accountId: 101010101010
     region: us-east-1
-    # location: './' optional field for where to find serverless.yml - primarily used for typescript
 ```
 
 Although not neccessary, it's strongly recomended to add the folder with the downloaded step function executables to `.gitignore`.  By default, this path is `./.step-functions-local`.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ custom:
     eventBridgeEvents:
       enabled: true
       endpoint: http://localhost:4010
+  sqsUrl: http://localhost:4566/101010101010/example-queue
 
 functions:
   hello:
@@ -98,6 +99,13 @@ stepFunctions:
           FirstState:
             Type: Task
             Resource: Fn::GetAtt: [hello, Arn]
+            Next: send_message
+          send_message:
+            Type: Task
+            Resource: arn:aws:states:::sqs:sendMessage
+            Parameters:
+              QueueUrl: ${self:custom.sqsUrl}
+              "MessageBody.$": "$"
             Next: wait_using_seconds
           wait_using_seconds:
             Type: Wait

--- a/index.js
+++ b/index.js
@@ -81,38 +81,7 @@ class ServerlessStepFunctionsLocal {
   }
 
   async getStepFunctionsFromConfig() {
-    const fromYamlFile = (serverlessYmlPath) =>
-      this.serverless.yamlParser.parse(serverlessYmlPath);
-
-    let parsed = {};
-    let parser = null;
-
-    if (!this.serverless.service.stepFunctions) {
-      let { servicePath } = this.serverless.config;
-
-      if (!servicePath) {
-        throw new Error('service path not found');
-      }
-      const serviceFileName =
-        this.options.config ||
-        this.serverless.config.serverless.service.serviceFilename ||
-        'serverless.yml';
-      if (this.serverless.service.custom &&
-        this.serverless.service.custom.stepFunctionsLocal &&
-        this.serverless.service.custom.stepFunctionsLocal.location) {
-        servicePath = this.serverless.service.custom.stepFunctionsLocal.location
-      }
-      const configPath = path.join(servicePath, serviceFileName);
-      if (['.js', '.json', '.ts'].includes(path.extname(configPath))) {
-        parser = this.loadFromRequiredFile;
-      } else {
-        parser = fromYamlFile;
-      }
-      parsed = await parser(configPath);
-    } else {
-      parsed = this.serverless.service;
-    }
-
+    const parsed = this.serverless.configurationInput;
     this.stateMachines = parsed.stepFunctions.stateMachines;
 
     if (parsed.custom &&
@@ -124,16 +93,6 @@ class ServerlessStepFunctionsLocal {
         parsed.custom.stepFunctionsLocal.TaskResourceMapping
       );
     }
-  }
-
-  // This function must be ignored since mocking the require system is more
-  // dangerous than beneficial
-  loadFromRequiredFile(serverlessYmlPath) {
-    /* istanbul ignore next */
-    // eslint-disable-next-line global-require, import/no-dynamic-require
-    const fileContents = require(serverlessYmlPath);
-    /* istanbul ignore next */
-    return Promise.resolve(fileContents);
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-step-functions-local",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-step-functions-local",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Run AWS step functions offline with Serverless",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "stepfunctions-localhost": "^0.2.0",
     "tcp-port-used": "^1.0.1"
   },
+  "peerDependencies": {
+    "serverless": "^2.32.0"
+  },
   "xo": {
     "space": true
   },


### PR DESCRIPTION
## Purpose

Allow variable resolution in the step functions config, following this approach: https://github.com/serverless-operations/serverless-step-functions/pull/451.

This allows for variables to be properly resolved instead of appearing as strings as-is. `Resource` variables can currently be replaced through `TaskResourceMapping`, but other essential fields like `QueueUrl` for `sqs:sendMessage` resources need to be supported. Instead of overloading `TaskResourceMapping` with custom syntax, allow variable resolution to give users full flexibility to configure however they want.

`TaskResourceMapping` is still handy, but can consider deprecating it in the future since the functionality is now possible through variables, and there'll be one less thing to maintain.

The example below (and in the README) shows how to reference an arbitrary custom variable.

```yaml
custom:
  ...
  sqsUrl: http://localhost:4566/101010101010/example-queue

stepFunctions:
  stateMachines:
    WaitMachine:
      definition:
        StartAt: send_message
        States:
          send_message:
            Type: Task
            Resource: arn:aws:states:::sqs:sendMessage
            Parameters:
              QueueUrl: ${self:custom.sqsUrl}
              "MessageBody.$": "$"
            End: true
```

## Notes
- I'm not 100% sure how the resolver works internally but the source PR did away with the changes applied in https://github.com/codetheweb/serverless-step-functions-local/pull/2, so I assume it automagically works with non-yaml configs.
- This is only supported on Serverless v2.32.0 and above, added peer dependency.
- Since this is a potentially breaking change, bump minor version