### PR TITLE
Fix multiple state machines error

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,17 +115,16 @@ class ServerlessStepFunctionsLocal {
   }
 
   async createEndpoints() {
-    const endpoints = await Promise.all(Object.keys(this.stateMachines).map(stateMachineName => this.stepfunctionsAPI.createStateMachine({
-      definition: JSON.stringify(this.stateMachines[stateMachineName].definition),
-      name: stateMachineName,
-      roleArn: `arn:aws:iam::${this.config.accountId}:role/DummyRole`
-    }).promise()
-    ));
+    for (const stateMachineName in this.stateMachines) {
+      const endpoint = await this.stepfunctionsAPI.createStateMachine({
+        definition: JSON.stringify(this.stateMachines[stateMachineName].definition),
+        name: stateMachineName,
+        roleArn: `arn:aws:iam::${this.config.accountId}:role/DummyRole`
+      }).promise();
 
-    // Set environment variables with references to ARNs
-    endpoints.forEach(endpoint => {
+      // Set environment variables with references to ARNs
       process.env[`OFFLINE_STEP_FUNCTIONS_ARN_${endpoint.stateMachineArn.split(':')[6]}`] = endpoint.stateMachineArn;
-    });
+    }
   }
 
   sendEventBridgeEvent(logLine) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-step-functions-local",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-step-functions-local",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Run AWS step functions offline with Serverless",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Purpose

There is a strange `DUPLICATE_STATE_NAME` error when registering multiple state machines with similarly named steps, even though the state machines are named differently and should be completely independent.

Serverless config:
```yaml
stepFunctions:
  validate: true
  stateMachines:
    ExampleStateMachine1:
      name: ExampleStateMachine1
      definition:
        Comment: "Example 1"
        StartAt: PassTask
        States:
          PassTask:
            Type: Pass
            Next: AnotherPassTask
          AnotherPassTask:
            Type: Pass
            End: true
    ExampleStateMachine2:
      name: ExampleStateMachine2
      definition:
        Comment: "Example 2"
        StartAt: PassTask
        States:
          PassTask:
            Type: Pass
            Next: AnotherPassTask
          AnotherPassTask:
            Type: Pass
            End: true
```

Error:
```
[Serverless Step Functions Local] 2021-10-25 22:18:49.515: CreateStateMachine => {"requestClientOptions":{"readLimit":131073,"skipAppendUriPath":false},"requestMetricCollector":null,"customRequestHeaders":null,"customQueryParameters":null,"cloneSource":null,"sdkRequestTimeout":null,"sdkClientExecutionTimeout":null,"name":"ExampleStateMachine2","definition":"{\"Comment\":\"Example 2\",\"StartAt\":\"PassTask\",\"States\":{\"PassTask\":{\"Type\":\"Pass\",\"Next\":\"AnotherPassTask\"},\"AnotherPassTask\":{\"Type\":\"Pass\",\"End\":true}}}","roleArn":"arn:aws:iam::101010101010:role/DummyRole","type":null,"loggingConfiguration":null,"tags":null,"tracingConfiguration":null,"requestCredentials":null,"requestCredentialsProvider":null,"generalProgressListener":{"syncCallSafe":true},"readLimit":131073,"cloneRoot":null}
[Serverless Step Functions Local] 2021-10-25 22:18:49.515: CreateStateMachine => {"requestClientOptions":{"readLimit":131073,"skipAppendUriPath":false},"requestMetricCollector":null,"customRequestHeaders":null,"customQueryParameters":null,"cloneSource":null,"sdkRequestTimeout":null,"sdkClientExecutionTimeout":null,"name":"ExampleStateMachine1","definition":"{\"Comment\":\"Example 1\",\"StartAt\":\"PassTask\",\"States\":{\"PassTask\":{\"Type\":\"Pass\",\"Next\":\"AnotherPassTask\"},\"AnotherPassTask\":{\"Type\":\"Pass\",\"End\":true}}}","roleArn":"arn:aws:iam::101010101010:role/DummyRole","type":null,"loggingConfiguration":null,"tags":null,"tracingConfiguration":null,"requestCredentials":null,"requestCredentialsProvider":null,"generalProgressListener":{"syncCallSafe":true},"readLimit":131073,"cloneRoot":null}
 
 Invalid Definition --------------------------------------
 
  InvalidDefinition: Invalid State Machine Definition: ''DUPLICATE_STATE_NAME: Duplicate State name: PassTask at /States/PassTask', 'DUPLICATE_STATE_NAME: Duplicate State name: AnotherPassTask at /States/AnotherPassTask''

...

[Serverless Step Functions Local] 2021-10-25 22:23:10.847: [400] CreateStateMachine <= Invalid State Machine Definition: ''DUPLICATE_STATE_NAME: Duplicate State name: AnotherPassTask at /States/AnotherPassTask''
[Serverless Step Functions Local] 2021-10-25 22:23:10.849: [200] CreateStateMachine <= {"sdkResponseMetadata":null,"sdkHttpMetadata":null,"stateMachineArn":"arn:aws:states:ap-southeast-1:101010101010:stateMachine:ExampleStateMachine2","creationDate":1635171790840}

```

This error does not present itself when manually creating the state machines sequentially via AWS CLI using the exact inputs as shown in the logs.

## Approach

I suspect there is some race condition in AWS Step Functions Local when multiple create requests are done concurrently. This PR simply makes the requests synchronous instead of using `Promise.all` and it seems to fix the issue.

```
[Serverless Step Functions Local] 2021-10-25 22:26:15.437: CreateStateMachine => {"requestClientOptions":{"readLimit":131073,"skipAppendUriPath":false},"requestMetricCollector":null,"customRequestHeaders":null,"customQueryParameters":null,"cloneSource":null,"sdkRequestTimeout":null,"sdkClientExecutionTimeout":null,"name":"ExampleStateMachine1","definition":"{\"Comment\":\"Example 1\",\"StartAt\":\"PassTask\",\"States\":{\"PassTask\":{\"Type\":\"Pass\",\"Next\":\"AnotherPassTask\"},\"AnotherPassTask\":{\"Type\":\"Pass\",\"End\":true}}}","roleArn":"arn:aws:iam::101010101010:role/DummyRole","type":null,"loggingConfiguration":null,"tags":null,"tracingConfiguration":null,"requestCredentials":null,"requestCredentialsProvider":null,"generalProgressListener":{"syncCallSafe":true},"readLimit":131073,"cloneRoot":null}
[Serverless Step Functions Local] 2021-10-25 22:26:15.467: [200] CreateStateMachine <= {"sdkResponseMetadata":null,"sdkHttpMetadata":null,"stateMachineArn":"arn:aws:states:ap-southeast-1:101010101010:stateMachine:ExampleStateMachine1","creationDate":1635171975453}
[Serverless Step Functions Local] 2021-10-25 22:26:15.470: CreateStateMachine => {"requestClientOptions":{"readLimit":131073,"skipAppendUriPath":false},"requestMetricCollector":null,"customRequestHeaders":null,"customQueryParameters":null,"cloneSource":null,"sdkRequestTimeout":null,"sdkClientExecutionTimeout":null,"name":"ExampleStateMachine2","definition":"{\"Comment\":\"Example 2\",\"StartAt\":\"PassTask\",\"States\":{\"PassTask\":{\"Type\":\"Pass\",\"Next\":\"AnotherPassTask\"},\"AnotherPassTask\":{\"Type\":\"Pass\",\"End\":true}}}","roleArn":"arn:aws:iam::101010101010:role/DummyRole","type":null,"loggingConfiguration":null,"tags":null,"tracingConfiguration":null,"requestCredentials":null,"requestCredentialsProvider":null,"generalProgressListener":{"syncCallSafe":true},"readLimit":131073,"cloneRoot":null}
[Serverless Step Functions Local] 2021-10-25 22:26:15.472: [200] CreateStateMachine <= {"sdkResponseMetadata":null,"sdkHttpMetadata":null,"stateMachineArn":"arn:aws:states:ap-southeast-1:101010101010:stateMachine:ExampleStateMachine2","creationDate":1635171975471}
```