### PR TITLE
Add support for StepFunction using Fn::GetAtt

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,6 +150,10 @@ class ServerlessStepFunctionsLocal {
             input.Resource = replacements[parentKey];
           }
         }
+        // Add support for StepFunction
+        if (input.Parameters && input.Parameters.StateMachineArn && input.Parameters.StateMachineArn['Fn::GetAtt'])  {
+          input.Parameters.StateMachineArn = replacements[input.Parameters.StateMachineArn['Fn::GetAtt'][0]]
+        }
 
         // Recursive replacement of nested states
         this.replaceTaskResourceMappings(property, replacements, key);


### PR DESCRIPTION
Hello,

This PR is about to add support for Fn::GetAtt to have the arn from the mapping entries.
This allows to have stepFunction being able to call stepFunction.

Regards.