### PR TITLE
Fix for parent-child state machine calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,6 +98,7 @@ class ServerlessStepFunctionsLocal {
       lambdaEndpoint: this.config.lambdaEndpoint,
       region: this.config.region,
       waitTimeScale: this.config.waitTimeScale,
+      stepFunctionsEndpoint: this.config.stepFunctionsEndpoint,
     });
 
     if (this.usedEndpointFromServerlessOffline) {


### PR DESCRIPTION
## Description
- Fix for error when executing a child state machine from parent state machine as a task

## Dependencies
- https://github.com/codetheweb/stepfunctions-localhost/pull/14

## Steps to replicate issue:
1. Given the following simple serverless.yml example:
```
service: my-step-functions-local

provider:
  name: aws
  runtime: nodejs18.x
  region: us-east-2

custom:
  application: MyStepFunctions

  stepFunctionsLocal:
    accountId: 101010101010
    region: us-east-2

stepFunctions:
  stateMachines:
    childStateMachine:
      name: child-state-machine
      definition:
        Comment: "Child State Machine"
        StartAt: SayHello
        States:
          SayHello:
            Type: Pass
            Result: "Hello from Child State Machine"
            End: true
    parentStateMachine:
      name: parent-state-machine
      definition:
        Comment: "Parent State Machine"
        StartAt: ExecuteChildStateMachine
        States:
          ExecuteChildStateMachine:
            Type: Task
            Resource: "arn:aws:states:::states:startExecution.sync:2"
            Parameters:
              StateMachineArn: "arn:aws:states:us-east-2:101010101010:stateMachine:child-state-machine"
            TimeoutSeconds: 599
            End: true

plugins:
  - serverless-step-functions
  - serverless-step-functions-local
  - serverless-offline
```

2. Run `sls offline start`
3. Execute Child State Machine directly by running `aws stepfunctions --endpoint-url http://localhost:8083 start-execution --state-machine-arn arn:aws:states:us-east-2:101010101010:stateMachine:child-state-machine` (working ✅)
4. Execute Parent State Machine (which executes the child state machine as a task) by running `aws stepfunctions --endpoint-url http://localhost:8083 start-execution --state-machine-arn arn:aws:states:us-east-2:101010101010:stateMachine:parent-state-machine` (not working ❌). Getting this error message:
    ```
    arn:aws:states:us-east-2:101010101010:execution:parent-state-machine:bbbdc711-2462-4dcc-b6d9-f242c84dbd2c : {"Type":"TaskFailed","PreviousEventId":4,"TaskFailedEventDetails":{"ResourceType":"states","Resource":"startExecution.sync:2","Error":"StepFunctions-AWSStepFunctionsException","Cause":"The security token included in the request is invalid. (Service: AWSStepFunctions; Status Code: 400; Error Code: UnrecognizedClientException; Request ID: 338d459f-04e2-4f57-89cc-8d9b9364cfa8; Proxy: null)"}}
    ```

This PR along with the Dependency PR mentioned above should solve this issue.